### PR TITLE
Fix spec for variant function

### DIFF
--- a/lib/turboprop/variants.ex
+++ b/lib/turboprop/variants.ex
@@ -315,7 +315,7 @@ defmodule Turboprop.Variants do
     input
   end
 
-  @spec variant(map(), keyword()) :: binary()
+  @spec variant(keyword(), keyword()) :: binary()
   @doc """
   Computes a component's classes.
 


### PR DESCRIPTION
Small change to make dialyzer happy.

I started getting errors about no return and realized the spec was wrong (was saying map instead of keyword)